### PR TITLE
feat: bundle openttd-admin with image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,21 @@
+FROM golang:1.22 AS openttd-admin
+RUN go install github.com/sdassow/openttd-admin@d16c9d5
+
 FROM ubuntu:22.04
 
 ARG PATCH_VERSION="0.53.0"
 ARG OPENGFX_VERSION="7.1"
+
+# Copy over openttd-admin and add basic wrapper
+COPY --from=openttd-admin /go/bin/openttd-admin /usr/local/bin/openttd-admin
+ADD rcon.sh /usr/local/bin/rcon
 
 ADD prepare.sh /tmp/prepare.sh
 ADD cleanup.sh /tmp/cleanup.sh
 ADD buildconfig /tmp/buildconfig
 ADD --chown=1000:1000 openttd.sh /openttd.sh
 
-RUN chmod +x /tmp/prepare.sh /tmp/cleanup.sh /openttd.sh
+RUN chmod +x /tmp/prepare.sh /tmp/cleanup.sh /openttd.sh /usr/local/bin/rcon
 RUN /tmp/prepare.sh \
     && /tmp/cleanup.sh
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ To set a new value to an enviroment variable use docker's `-e ` parameter (see h
 By default docker does not expose the containers on your network. This must be done manually with `-p` parameter (see [here](https://docs.docker.com/engine/reference/commandline/run/) for more details on -p).
 If your openttd config is set up to listen on port 3979 you need to map the container port to your machines network like so `-p 3979:3979` where the first reference is the host machines port and the second the container port.
 
+### Management
+
+This image includes [openttd-admin](https://github.com/sdassow/openttd-admin) to allow you to easily manage your OpenTTD
+server. In addition, a simple wrapper script, `rcon`, is included that allows you to connect directly to the OpenTTD
+rcon port. For example:
+
+    docker exec -it [container-name] rcon
+
 ### Examples
 
 Run Openttd and expose the default ports.
@@ -77,10 +85,6 @@ services:
       PUID: "1003"
       PGID: "1004"
       loadgame: last-autosave
-
-  console:
-    image: golang
-    command: sleep infinity
 ```
 
 You can also find a docker-compose file in this repo which contains the same config

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,3 @@ services:
             PUID: "1003"
             PGID: "1004"
             loadgame: last-autosave
-
-    console:
-            image: golang
-            command: sleep infinity

--- a/rcon.sh
+++ b/rcon.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+openttd-admin rcon -c /home/openttd/.config/openttd/openttd.cfg
+
+# Since the openttd-admin doesn't always exit cleanly, help it out a bit
+reset -I


### PR DESCRIPTION
This PR bundles [openttd-admin](https://github.com/sdassow/openttd-admin) in the built image, allowing easier management of the running openttd server. It also updates documentation accordingly.

Closes #3.