### PR TITLE
change rcon.sh search path to that mapped as default in docker-compos…

### DIFF
--- a/rcon.sh
+++ b/rcon.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-openttd-admin rcon -c /home/openttd/.config/openttd/openttd.cfg
+openttd-admin rcon -c /home/openttd/.local/share/openttd/openttd.cfg
 
 # Since the openttd-admin doesn't always exit cleanly, help it out a bit
 reset -I


### PR DESCRIPTION
Container rcon script looks for openttd.cfg as if it is searching a local user's .config path, but the Docker container usually expects openttd conf files to be mounted at /home/openttd/.local/share/openttd/ (or at least, that is the default config in the example docker compose file).